### PR TITLE
Fix for compatibility with upcoming quanteda v2 release

### DIFF
--- a/R/get_parameter.R
+++ b/R/get_parameter.R
@@ -95,7 +95,7 @@ get_parameter.JST_reversed.result.phi <- function(x) {
 }
 
 get_parameter.JST.result.pi <- function(x) {
-  if (length(x@docvars > 0)) {
+  if (length(x@docvars) > 0) {
     docvars <- x@docvars
     docvars$docID <- rownames(docvars)
 
@@ -107,7 +107,7 @@ get_parameter.JST.result.pi <- function(x) {
 }
 
 get_parameter.JST.result.theta <- function(x) {
-  if (length(x@docvars > 0)) {
+  if (length(x@docvars) > 0) {
     docvars <- x@docvars
     docvars$docID <- rownames(docvars)
 

--- a/R/jst.R
+++ b/R/jst.R
@@ -184,7 +184,8 @@ jst <- function(dfm,
       phi.termScores = phi.termScores,
       numTopics = numTopics,
       numSentiments = numSentiLabs,
-      docvars = quanteda::docvars(dfm)
+      docvars = data.frame(quanteda::docvars(dfm), row.names = docID,
+                           stringsAsFactors = FALSE)
     )
   )
 }

--- a/R/jst_reversed.R
+++ b/R/jst_reversed.R
@@ -188,7 +188,8 @@ jst_reversed <- function(dfm,
       phi.termScores = phi.termScores,
       numTopics = numTopics,
       numSentiments = numSentiLabs,
-      docvars = quanteda::docvars(dfm)
+      docvars = data.frame(quanteda::docvars(dfm), row.names = docID,
+                           stringsAsFactors = FALSE)
     )
   )
 }


### PR DESCRIPTION
Implements fixes for compatibility with the upcoming quanteda v2 release. In that structure, the docvars data.frame no longer uses row.names to store the document ID.

I also found a bug in the conditional code for getting the theta parameter, which I fixed.

Note: In `jst.R` I only changed lines 187-188, so I am not sure why the diff is indicating that the entire file has been replaced. Maybe a difference in the end of line characters between my editor and yours? 